### PR TITLE
Adelle/wire up service map

### DIFF
--- a/components/customNodes.tsx
+++ b/components/customNodes.tsx
@@ -5,9 +5,6 @@ import "flowbite";
 import "twind";
 import {useState} from "https://esm.sh/stable/preact@10.15.1/denonext/hooks.js";
 
-const getHandlePosition = (input: string) => {
-    return input === "top" ? Position.Top : Position.Bottom;
-};
 
 export const Service = ({data}: any) => {
     return (
@@ -136,12 +133,12 @@ export const Producer = ({data}) => {
             </div>
             <Handle
                 type="source"
-                position={getHandlePosition(data.source)}
+                position={Position.Bottom}
                 style={{opacity: 0}}
             />
             <Handle
                 type="target"
-                position={getHandlePosition(data.target)}
+                position={Position.Top}
                 style={{opacity: 0}}
             />
         </div>
@@ -216,12 +213,12 @@ export const Consumer = ({data}) => {
             </div>
             <Handle
                 type="source"
-                position={getHandlePosition(data.source)}
+                position={Position.Top}
                 style={{opacity: 0}}
             />
             <Handle
                 type="target"
-                position={getHandlePosition(data.target)}
+                position={Position.Bottom}
                 style={{opacity: 0}}
             />
         </div>
@@ -229,7 +226,6 @@ export const Consumer = ({data}) => {
 };
 
 export const Platform = ({data}: any) => {
-    console.log(data?.label)
     return (
         <div
             className={"z-0 bg-web rounded-md border-1 border-black h-[145px] w-[145px] shadow-xl flex justify-center" +

--- a/components/customNodes.tsx
+++ b/components/customNodes.tsx
@@ -9,7 +9,7 @@ const getHandlePosition = (input: string) => {
     return input === "top" ? Position.Top : Position.Bottom;
 };
 
-export const Service = ({data}) => {
+export const Service = ({data}: any) => {
     return (
         <div class="h-[100px]">
             <div
@@ -23,7 +23,7 @@ export const Service = ({data}) => {
                     className={"h-[40px]"}
                 />
                 <div>
-                    <h2 className={"text-lg mr-3"}>$Service Name</h2>
+                    <h2 className={"text-lg mr-3"}>{data.label}</h2>
                     <p class="text-streamdalPurple text-xs font-semibold mt-1">
                         4 instances
                     </p>
@@ -68,7 +68,7 @@ export const Service = ({data}) => {
     );
 };
 
-export const Participants = ({data}) => {
+export const Producer = ({data}) => {
     const [isOpen, setIsOpen] = useState<boolean>(false);
 
     const handleModalOpen = () => {
@@ -148,7 +148,88 @@ export const Participants = ({data}) => {
     );
 };
 
-export const Platform = ({data}) => {
+export const Consumer = ({data}) => {
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+
+    const handleModalOpen = () => {
+        setIsOpen(true);
+    };
+
+    return (
+        <div className="h-[96px] flex items-center z-40">
+            <div
+                data-popover-target="popover"
+                data-popover-trigger="hover"
+                type="button"
+                onClick={handleModalOpen}
+                className="w-[205px] h-[64px] bg-white rounded-md shadow-lg border-1 border-purple-200 flex items-center justify-between px-1"
+            >
+                <IconGripVertical
+                    class="w-6 h-6 text-purple-100 cursor-grab"
+                    id="dragHandle"
+                />
+                <img src={"/images/placeholder-icon.png"} className="w-[30px]"/>
+                <a href={`/flow/${data.label.toLowerCase()}`}>
+                    <div className={"flex flex-col"}>
+                        <h2 className={"text-[16px]"}>
+                            Item Name
+                        </h2>
+                        <h3 class="text-xs text-gray-500">{data.label}</h3>
+                    </div>
+                </a>
+                <ParticipantsMenu id={data.label}/>
+            </div>
+            <div
+                data-popover
+                id="popover"
+                role="tooltip"
+                class="absolute z-10 invisible inline-block w-64 text-sm text-gray-500 transition-opacity duration-300 bg-white border border-gray-200 rounded-lg shadow-sm opacity-0 dark:text-gray-400 dark:border-gray-600 dark:bg-gray-800"
+            >
+                <div
+                    class="px-3 py-2 bg-gray-100 border-b border-gray-200 rounded-t-lg dark:border-gray-600 dark:bg-gray-700">
+                    <h3 class="font-semibold text-gray-900 dark:text-white">
+                        Popover no arrow
+                    </h3>
+                </div>
+                <div class="px-3 py-2">
+                    <p>And here's some amazing content. It's very engaging. Right?</p>
+                </div>
+            </div>
+            <span class="sr-only">Notifications</span>
+            <div
+                class="absolute inline-flex items-center justify-evenly w-8 h-5 text-xs text-[#652015] bg-red-200 rounded-md top-2 -right-2 dark:border-gray-900">
+                <svg
+                    width="11"
+                    height="12"
+                    viewBox="0 0 11 12"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        d="M7.41667 9.16667H10.3333L9.51375 8.34708C9.40369 8.237 9.31639 8.10631 9.25684 7.96248C9.19728 7.81865 9.16664 7.6645 9.16667 7.50883V5.66667C9.16676 4.94271 8.94242 4.23653 8.52455 3.64535C8.10668 3.05417 7.51583 2.60706 6.83333 2.36558V2.16667C6.83333 1.85725 6.71042 1.5605 6.49162 1.34171C6.27283 1.12292 5.97609 1 5.66667 1C5.35725 1 5.0605 1.12292 4.84171 1.34171C4.62292 1.5605 4.5 1.85725 4.5 2.16667V2.36558C3.14083 2.84625 2.16667 4.143 2.16667 5.66667V7.50942C2.16667 7.82325 2.04183 8.12483 1.81958 8.34708L1 9.16667H3.91667M7.41667 9.16667H3.91667M7.41667 9.16667V9.75C7.41667 10.2141 7.23229 10.6592 6.9041 10.9874C6.57592 11.3156 6.1308 11.5 5.66667 11.5C5.20254 11.5 4.75742 11.3156 4.42923 10.9874C4.10104 10.6592 3.91667 10.2141 3.91667 9.75V9.16667"
+                        stroke="#652015"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                    />
+                </svg>
+                4
+            </div>
+            <Handle
+                type="source"
+                position={getHandlePosition(data.source)}
+                style={{opacity: 0}}
+            />
+            <Handle
+                type="target"
+                position={getHandlePosition(data.target)}
+                style={{opacity: 0}}
+            />
+        </div>
+    );
+};
+
+export const Platform = ({data}: any) => {
+    console.log(data?.label)
     return (
         <div
             className={"z-0 bg-web rounded-md border-1 border-black h-[145px] w-[145px] shadow-xl flex justify-center" +
@@ -156,7 +237,7 @@ export const Platform = ({data}) => {
         >
             <div className={"flex justify-center flex-col items-center"}>
                 <img src={"/images/kafka-dark.svg"} className="w-[30px]"/>
-                <p className={"z-10 mt-2 text-white"}>Kafka</p>
+                <p className={"z-10 mt-2 text-white"}>{data?.label}</p>
             </div>
             <Handle
                 type="source"

--- a/components/customNodes.tsx
+++ b/components/customNodes.tsx
@@ -225,7 +225,7 @@ export const Consumer = ({data}) => {
     );
 };
 
-export const Platform = ({data}: any) => {
+export const Audience = ({data}: any) => {
     return (
         <div
             className={"z-0 bg-web rounded-md border-1 border-black h-[145px] w-[145px] shadow-xl flex justify-center" +

--- a/components/customNodes.tsx
+++ b/components/customNodes.tsx
@@ -10,7 +10,7 @@ export const Service = ({data}: any) => {
     return (
         <div class="h-[100px]">
             <div
-                class="h-[80px] w-[280px] flex items-center justify-between bg-white rounded shadow-lg z-10 border-1 border-purple-200 px-2">
+                class="h-[80px] w-[320px] flex items-center justify-between bg-white rounded shadow-lg z-10 border-1 border-purple-200 px-2">
                 <IconGripVertical
                     class="w-6 h-6 text-purple-100 cursor-grab"
                     id="dragHandle"
@@ -20,7 +20,7 @@ export const Service = ({data}: any) => {
                     className={"h-[40px]"}
                 />
                 <div>
-                    <h2 className={"text-lg mr-3"}>{data.label}</h2>
+                    <h2 className={"text-lg mr-3 ml-2"}>{data.label}</h2>
                     <p class="text-streamdalPurple text-xs font-semibold mt-1">
                         4 instances
                     </p>
@@ -65,8 +65,8 @@ export const Service = ({data}: any) => {
     );
 };
 
-export const Producer = ({data}) => {
-    const [isOpen, setIsOpen] = useState<boolean>(false);
+export const Producer = ({data}: any) => {
+    const [isOpen, setIsOpen] = useState(false);
 
     const handleModalOpen = () => {
         setIsOpen(true);
@@ -145,8 +145,8 @@ export const Producer = ({data}) => {
     );
 };
 
-export const Consumer = ({data}) => {
-    const [isOpen, setIsOpen] = useState<boolean>(false);
+export const Consumer = ({data}: any) => {
+    const [isOpen, setIsOpen] = useState(false);
 
     const handleModalOpen = () => {
         setIsOpen(true);
@@ -225,7 +225,7 @@ export const Consumer = ({data}) => {
     );
 };
 
-export const Audience = ({data}: any) => {
+export const Component = ({data}: any) => {
     return (
         <div
             className={"z-0 bg-web rounded-md border-1 border-black h-[145px] w-[145px] shadow-xl flex justify-center" +

--- a/components/modals/InfoModal.tsx
+++ b/components/modals/InfoModal.tsx
@@ -6,7 +6,7 @@ export const InfoModal = (props: any) => {
     return (
         <div>
             <div
-                tabIndex="-1"
+                tabIndex={-1}
                 class="absolute mt-20 right-10 z-50 w-[308px] h-[560px] p-4 overflow-x-hidden overflow-y-hidden"
             >
                 <div class="relative w-full max-w-2xl max-h-full">

--- a/import_map.json
+++ b/import_map.json
@@ -17,6 +17,6 @@
     "@protobuf-ts/runtime": "https://esm.sh/@protobuf-ts/runtime@^2.9.0",
     "@protobuf-ts/runtime-rpc": "https://esm.sh/@protobuf-ts/runtime-rpc@^2.9.0",
     "@protobuf-ts/grpcweb-transport": "https://esm.sh/@protobuf-ts/grpcweb-transport@^2.9.0",
-    "snitch-protos/": "https://deno.land/x/snitch_protos@v0.0.52/"
+    "snitch-protos/": "https://deno.land/x/snitch_protos@v0.0.55/"
   }
 }

--- a/islands/flow.tsx
+++ b/islands/flow.tsx
@@ -111,7 +111,8 @@ const nodeTypes = {
     service: Service,
     participants: Participants,
 };
-export default function Flow() {
+export default function Flow(props: any) {
+    console.log("these here be the props", props)
     const [nodes, , onNodesChange] = useNodesState(initialNodes);
 
     return (

--- a/islands/flow.tsx
+++ b/islands/flow.tsx
@@ -11,7 +11,8 @@ import {
 } from "https://esm.sh/v128/@reactflow/core@11.7.4/X-YS9AdHlwZXMvcmVhY3Q6cHJlYWN0L2NvbXBhdCxyZWFjdC1kb206cHJlYWN0L2NvbXBhdCxyZWFjdDpwcmVhY3QvY29tcGF0CmUvcHJlYWN0L2NvbXBhdA/denonext/core.mjs";
 import "flowbite";
 import { useEffect } from "https://esm.sh/preact@10.15.1/hooks";
-import { string } from "https://deno.land/x/zod@v3.21.4/types.ts";
+import { PipelineInfo } from "snitch-protos/protos/info.ts";
+import { GetServiceMapResponse } from "snitch-protos/protos/external.ts";
 
 const nodeTypes = {
   component: Component,
@@ -34,14 +35,14 @@ export type Node = {
   };
 };
 
-export default function Flow(props: any) {
+export default function Flow({ data }: { data: GetServiceMapResponse }) {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgeChange] = useEdgesState([]);
 
   useEffect(() => {
     //todo: add functionality for more than one service and component
-    const keys = Object.keys(props.props.serviceMap);
-    const serviceMap = props.props.serviceMap;
+    const keys = Object.keys(data.serviceMap);
+    const serviceMap = data.serviceMap;
 
     let nodes = [
       {
@@ -58,7 +59,7 @@ export default function Flow(props: any) {
         targetPosition: "left",
         position: { x: 215, y: 350 },
         data: {
-          label: `${serviceMap[keys[0]].pipelines[0].audience.componentName}`,
+          label: `${serviceMap[keys[0]].pipelines[0].audience?.componentName}`,
         },
       },
     ];
@@ -69,8 +70,8 @@ export default function Flow(props: any) {
   }, []);
 
   useEffect(() => {
-    //edges created based off the node created
-    const unique = nodes.reduce((acc: any, node: Node) => {
+    //edges created based off the nodes created
+    const unique = nodes.reduce((acc: [], node: Node) => {
       if (!acc.length || !acc.find((item: Node) => item.type === node.type)) {
         return [...acc, node];
       } else {
@@ -112,10 +113,10 @@ export default function Flow(props: any) {
     setEdges(newEdges);
   }, [nodes]);
 
-  const getOperation = (pipeline: any) => {
-    //creates producer and consumer nodes
-    return pipeline.map((component: any, i: number) => {
-      switch (component.audience.operationType) {
+  const getOperation = (pipeline: PipelineInfo[]) => {
+    //creates producer and consumer nodes based on audience data
+    return pipeline.map((component: PipelineInfo, i: number) => {
+      switch (component.audience?.operationType) {
         case (1):
           return {
             id: `${2000 + i}`,

--- a/islands/flow.tsx
+++ b/islands/flow.tsx
@@ -5,43 +5,46 @@ import {
     useNodesState,
 } from "https://esm.sh/v128/@reactflow/core@11.7.4/X-YS9AdHlwZXMvcmVhY3Q6cHJlYWN0L2NvbXBhdCxyZWFjdC1kb206cHJlYWN0L2NvbXBhdCxyZWFjdDpwcmVhY3QvY29tcGF0CmUvcHJlYWN0L2NvbXBhdA/denonext/core.mjs";
 import "flowbite";
+import { useEffect } from "https://esm.sh/preact@10.15.1/hooks";
 
-const initialNodes = [
-    {
-        id: "1",
-        type: "service",
-        dragHandle: "#dragHandle",
-        position: {x: 150, y: 0},
-        data: {label: "Service"},
-    },
-    {
-        id: "2",
-        type: "participants",
-        dragHandle: "#dragHandle",
-        position: {x: 50, y: 200},
-        zIndex: 2,
-        data: {label: "Consumer", source: "top", target: "bottom"},
-    },
-    {
-        id: "3",
-        type: "participants",
-        dragHandle: "#dragHandle",
-        position: {x: 325, y: 200},
-        zIndex: 2,
-        data: {label: "Producer", source: "bottom", target: "top"},
-    },
-    {
-        id: "4",
-        type: "platform",
-        sourcePosition: "right",
-        targetPosition: "left",
-        position: {x: 215, y: 350},
-    },
-];
+
+// const initialNodes = [
+//     {
+//         id: "1",
+//         type: "service",
+//         dragHandle: "#dragHandle",
+//         position: {x: 150, y: 0},
+//         data: {label: "testing"},
+//     },
+//     {
+//         id: "2",
+//         type: "participants",
+//         dragHandle: "#dragHandle",
+//         position: {x: 50, y: 200},
+//         zIndex: 2,
+//         data: {label: "Consumer", source: "top", target: "bottom"},
+//     },
+//     {
+//         id: "3",
+//         type: "participants",
+//         dragHandle: "#dragHandle",
+//         position: {x: 325, y: 200},
+//         zIndex: 2,
+//         data: {label: "Producer", source: "bottom", target: "top"},
+//     },
+//     {
+//         id: "4",
+//         type: "platform",
+//         sourcePosition: "right",
+//         targetPosition: "left",
+//         position: {x: 215, y: 350},
+//     },
+// ];
+
 const initialEdges = [
     {
         id: "e1-2",
-        source: "2",
+        source: "2000",
         target: "1",
         targetHandle: "c",
         sourceHandle: "a",
@@ -108,12 +111,88 @@ const initialEdges = [
 
 const nodeTypes = {
     platform: Platform,
-    service: Service,
+    producer: Producer,
+    consumer: Consumer,
     participants: Participants,
 };
+
 export default function Flow(props: any) {
-    console.log("these here be the props", props)
-    const [nodes, , onNodesChange] = useNodesState(initialNodes);
+    // console.log("data we want", props.props)
+
+    // console.log("these here be the props", props)
+    const [nodes, setNodes , onNodesChange] = useNodesState([]);
+    
+    useEffect(() => {
+        const keys = Object.keys(props.props.serviceMap)
+        const serviceMap = props.props.serviceMap
+        console.log("useEffect", serviceMap[keys[0]])
+        let nodes = [
+            {
+                id: "1",
+                type: "service",
+                dragHandle: "#dragHandle",
+                position: {x: 150, y: 0},
+                data: {label: `${serviceMap[keys[0]].name}`},
+            },
+            {
+                id: "10",
+                type: "platform",
+                sourcePosition: "right",
+                targetPosition: "left",
+                position: {x: 215, y: 350},
+                data: {label: `${serviceMap[keys[0]].pipelines[0].audience.componentName}`}
+            },
+        ]
+        setNodes([...nodes, getProducers(serviceMap[keys[0]].producers), getConsumers(serviceMap[keys[0]].consumers)])
+    }, [])
+
+    useEffect(() => {
+
+    }, [nodes])
+
+    const getProducers = (prod : any) => {
+        if (prod.length === 0) {
+            return {
+                id: "1000",
+                type: "participants",
+                dragHandle: "#dragHandle",
+                position: {x: 325, y: 200},
+                zIndex: 2,
+                data: {label: "Producer", source: "bottom", target: "top"},
+            }
+        } else {
+            return {
+                id: "1000",
+                type: "participants",
+                dragHandle: "#dragHandle",
+                position: {x: 325, y: 200},
+                zIndex: 2,
+                data: {label: "Producer", source: "bottom", target: "top"},
+            }
+        }
+    }
+
+    const getConsumers = (prod : any) => {
+        if (prod.length === 0) {
+            return {
+                id: "2000",
+                type: "participants",
+                dragHandle: "#dragHandle",
+                position: {x: 50, y: 200},
+                zIndex: 2,
+                data: {label: "Consumer", source: "bottom", target: "top"},
+            }
+        } else {
+            return {
+                id: "2000",
+                type: "participants",
+                dragHandle: "#dragHandle",
+                position: {x: 50, y: 200},
+                zIndex: 2,
+                data: {label: "Consumer", source: "bottom", target: "top"},
+            }
+        }
+    }
 
     return (
         <div

--- a/islands/flow.tsx
+++ b/islands/flow.tsx
@@ -1,6 +1,6 @@
 import ReactFlow, { Background, Controls, useEdgesState } from "reactflow";
 import {
-  Audience,
+  Component,
   Consumer,
   Producer,
   Service,
@@ -14,7 +14,7 @@ import { useEffect } from "https://esm.sh/preact@10.15.1/hooks";
 import { string } from "https://deno.land/x/zod@v3.21.4/types.ts";
 
 const nodeTypes = {
-  audience: Audience,
+  component: Component,
   producer: Producer,
   consumer: Consumer,
   service: Service,
@@ -28,6 +28,7 @@ export type Node = {
     x: number;
     y: number;
   };
+  zIndex?: number;
   data: {
     label: string;
   };
@@ -38,9 +39,10 @@ export default function Flow(props: any) {
   const [edges, setEdges, onEdgeChange] = useEdgesState([]);
 
   useEffect(() => {
-    //this currently doesn't support more than one service or audience
+    //todo: add functionality for more than one service and component
     const keys = Object.keys(props.props.serviceMap);
     const serviceMap = props.props.serviceMap;
+
     let nodes = [
       {
         id: "1",
@@ -51,7 +53,7 @@ export default function Flow(props: any) {
       },
       {
         id: "10",
-        type: "audience",
+        type: "component",
         sourcePosition: "right",
         targetPosition: "left",
         position: { x: 215, y: 350 },
@@ -62,22 +64,34 @@ export default function Flow(props: any) {
     ];
     setNodes([
       ...nodes,
-      getProducers(serviceMap[keys[0]].producers),
-      getConsumers(serviceMap[keys[0]].consumers),
+      ...getOperation(serviceMap[keys[0]].pipelines),
     ]);
   }, []);
 
   useEffect(() => {
-    const newEdges = nodes.map((node: Node, i: number) => {
+    //edges created based off the node created
+    const unique = nodes.reduce((acc: any, node: Node) => {
+      if (!acc.length || !acc.find((item: Node) => item.type === node.type)) {
+        return [...acc, node];
+      } else {
+        return acc;
+      }
+    }, []);
+    const newEdges = unique.map((node: Node, i: number) => {
       let targetNode;
-      if (node.type === "service") {
-        targetNode = nodes.find((node: Node) => node.type === "producer");
-      } else if (node.type === "producer") {
-        targetNode = nodes.find((node: Node) => node.type === "audience");
-      } else if (node.type === "audience") {
-        targetNode = nodes.find((node: Node) => node.type === "consumer");
-      } else if (node.type === "consumer") {
-        targetNode = nodes.find((node: Node) => node.type === "service");
+      switch (node.type) {
+        case ("service"):
+          targetNode = nodes.find((node: Node) => node.type === "producer");
+          break;
+        case ("producer"):
+          targetNode = nodes.find((node: Node) => node.type === "component");
+          break;
+        case ("component"):
+          targetNode = nodes.find((node: Node) => node.type === "consumer");
+          break;
+        case ("consumer"):
+          targetNode = nodes.find((node: Node) => node.type === "service");
+          break;
       }
       return {
         id: i,
@@ -98,53 +112,35 @@ export default function Flow(props: any) {
     setEdges(newEdges);
   }, [nodes]);
 
-  const getProducers = (prod: []) => {
-    if (prod.length === 0) {
-      return {
-        id: "1000",
-        type: "producer",
-        dragHandle: "#dragHandle",
-        position: { x: 325, y: 200 },
-        zIndex: 2,
-        data: { label: "Producer", source: "bottom", target: "top" },
-      };
-    } else {
-      return {
-        id: "1000",
-        type: "producer",
-        dragHandle: "#dragHandle",
-        position: { x: 325, y: 200 },
-        zIndex: 2,
-        data: { label: "Producer", source: "bottom", target: "top" },
-      };
-    }
-  };
-
-  const getConsumers = (prod: []) => {
-    if (prod.length === 0) {
-      return {
-        id: "2000",
-        type: "consumer",
-        dragHandle: "#dragHandle",
-        position: { x: 50, y: 200 },
-        zIndex: 2,
-        data: { label: "Consumer", source: "bottom", target: "top" },
-      };
-    } else {
-      return {
-        id: "2000",
-        type: "consumer",
-        dragHandle: "#dragHandle",
-        position: { x: 50, y: 200 },
-        zIndex: 2,
-        data: { label: "Consumer", source: "bottom", target: "top" },
-      };
-    }
+  const getOperation = (pipeline: any) => {
+    //creates producer and consumer nodes
+    return pipeline.map((component: any, i: number) => {
+      switch (component.audience.operationType) {
+        case (1):
+          return {
+            id: `${2000 + i}`,
+            type: "consumer",
+            dragHandle: "#dragHandle",
+            position: { x: 50 + (i * 4), y: 200 },
+            zIndex: 2,
+            data: { label: "Consumer", source: "bottom", target: "top" },
+          };
+        case (2):
+          return {
+            id: `${1000 + i}`,
+            type: "producer",
+            dragHandle: "#dragHandle",
+            position: { x: 325 + (i * 4), y: 200 },
+            zIndex: 2,
+            data: { label: "Producer", source: "bottom", target: "top" },
+          };
+      }
+    });
   };
 
   return (
     <div
-      style={{ width: "100%", height: "100vh", zIndex: 0 }}
+      style={{ width: "100%", height: "100vh" }}
       class="m-0 z-10"
     >
       <ReactFlow

--- a/islands/flow.tsx
+++ b/islands/flow.tsx
@@ -1,218 +1,152 @@
-import ReactFlow, {Background, Controls} from "reactflow";
-import {Participants, Platform, Service} from "../components/customNodes.tsx";
+import ReactFlow, { Background, Controls, useEdgesState } from "reactflow";
 import {
-    MarkerType,
-    useNodesState,
+  Consumer,
+  Platform,
+  Producer,
+  Service,
+} from "../components/customNodes.tsx";
+import {
+  MarkerType,
+  useNodesState,
 } from "https://esm.sh/v128/@reactflow/core@11.7.4/X-YS9AdHlwZXMvcmVhY3Q6cHJlYWN0L2NvbXBhdCxyZWFjdC1kb206cHJlYWN0L2NvbXBhdCxyZWFjdDpwcmVhY3QvY29tcGF0CmUvcHJlYWN0L2NvbXBhdA/denonext/core.mjs";
 import "flowbite";
 import { useEffect } from "https://esm.sh/preact@10.15.1/hooks";
 
 
-// const initialNodes = [
-//     {
-//         id: "1",
-//         type: "service",
-//         dragHandle: "#dragHandle",
-//         position: {x: 150, y: 0},
-//         data: {label: "testing"},
-//     },
-//     {
-//         id: "2",
-//         type: "participants",
-//         dragHandle: "#dragHandle",
-//         position: {x: 50, y: 200},
-//         zIndex: 2,
-//         data: {label: "Consumer", source: "top", target: "bottom"},
-//     },
-//     {
-//         id: "3",
-//         type: "participants",
-//         dragHandle: "#dragHandle",
-//         position: {x: 325, y: 200},
-//         zIndex: 2,
-//         data: {label: "Producer", source: "bottom", target: "top"},
-//     },
-//     {
-//         id: "4",
-//         type: "platform",
-//         sourcePosition: "right",
-//         targetPosition: "left",
-//         position: {x: 215, y: 350},
-//     },
-// ];
-
-const initialEdges = [
-    {
-        id: "e1-2",
-        source: "2000",
-        target: "1",
-        targetHandle: "c",
-        sourceHandle: "a",
-        markerEnd: {
-            type: MarkerType.Arrow,
-            width: 20,
-            height: 20,
-            color: "#956CFF",
-        },
-        style: {
-            strokeWidth: 1.5,
-            stroke: "#956CFF",
-        },
-    },
-    {
-        id: "e1-3",
-        source: "1",
-        target: "3",
-        sourceHandle: "d",
-        markerEnd: {
-            type: MarkerType.Arrow,
-            width: 20,
-            height: 20,
-            color: "#956CFF",
-        },
-        style: {
-            strokeWidth: 1.5,
-            stroke: "#956CFF",
-        },
-    },
-    {
-        id: "e4-2",
-        source: "4",
-        targetHandle: "a",
-        target: "2",
-        markerEnd: {
-            type: MarkerType.Arrow,
-            width: 20,
-            height: 20,
-            color: "#956CFF",
-        },
-        style: {
-            strokeWidth: 1.5,
-            stroke: "#956CFF",
-        },
-    },
-    {
-        id: "e3-4",
-        source: "3",
-        targetHandle: "b",
-        target: "4",
-        markerEnd: {
-            type: MarkerType.Arrow,
-            width: 20,
-            height: 20,
-            color: "#956CFF",
-        },
-        style: {
-            strokeWidth: 1.5,
-            stroke: "#956CFF",
-        },
-    },
-];
-
 const nodeTypes = {
-    platform: Platform,
-    producer: Producer,
-    consumer: Consumer,
-    participants: Participants,
+  platform: Platform,
+  producer: Producer,
+  consumer: Consumer,
+  service: Service,
 };
 
 export default function Flow(props: any) {
-    // console.log("data we want", props.props)
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgeChange] = useEdgesState([]);
 
-    // console.log("these here be the props", props)
-    const [nodes, setNodes , onNodesChange] = useNodesState([]);
-    
-    useEffect(() => {
-        const keys = Object.keys(props.props.serviceMap)
-        const serviceMap = props.props.serviceMap
-        console.log("useEffect", serviceMap[keys[0]])
-        let nodes = [
-            {
-                id: "1",
-                type: "service",
-                dragHandle: "#dragHandle",
-                position: {x: 150, y: 0},
-                data: {label: `${serviceMap[keys[0]].name}`},
-            },
-            {
-                id: "10",
-                type: "platform",
-                sourcePosition: "right",
-                targetPosition: "left",
-                position: {x: 215, y: 350},
-                data: {label: `${serviceMap[keys[0]].pipelines[0].audience.componentName}`}
-            },
-        ]
-        setNodes([...nodes, getProducers(serviceMap[keys[0]].producers), getConsumers(serviceMap[keys[0]].consumers)])
-    }, [])
+  useEffect(() => {
+    const keys = Object.keys(props.props.serviceMap);
+    const serviceMap = props.props.serviceMap;
+    let nodes = [
+      {
+        id: "1",
+        type: "service",
+        dragHandle: "#dragHandle",
+        position: { x: 150, y: 0 },
+        data: { label: `${serviceMap[keys[0]].name}` },
+      },
+      {
+        id: "10",
+        type: "platform",
+        sourcePosition: "right",
+        targetPosition: "left",
+        position: { x: 215, y: 350 },
+        data: {
+          label: `${serviceMap[keys[0]].pipelines[0].audience.componentName}`,
+        },
+      },
+    ];
+    setNodes([
+      ...nodes,
+      getProducers(serviceMap[keys[0]].producers),
+      getConsumers(serviceMap[keys[0]].consumers),
+    ]);
+  }, []);
 
-    useEffect(() => {
+  useEffect(() => {
+    const newEdges = nodes.map((node: any, i: any) => {
+      let targetNode;
+      if (node.type === "service") {
+        targetNode = nodes.find((node) => node.type === "producer");
+      } else if (node.type === "producer") {
+        targetNode = nodes.find((node) => node.type === "platform");
+      } else if (node.type === "platform") {
+        targetNode = nodes.find((node) => node.type === "consumer");
+      } else {
+        targetNode = nodes.find((node) => node.type === "service");
+      }
+      return {
+        id: i,
+        source: node.id,
+        target: `${targetNode?.id}`,
+        markerEnd: {
+          type: MarkerType.Arrow,
+          width: 20,
+          height: 20,
+          color: "#956CFF",
+        },
+        style: {
+          strokeWidth: 1.5,
+          stroke: "#956CFF",
+        },
+      };
+    });
+    setEdges(newEdges)
+  }, [nodes]);
 
-    }, [nodes])
-
-    const getProducers = (prod : any) => {
-        if (prod.length === 0) {
-            return {
-                id: "1000",
-                type: "participants",
-                dragHandle: "#dragHandle",
-                position: {x: 325, y: 200},
-                zIndex: 2,
-                data: {label: "Producer", source: "bottom", target: "top"},
-            }
-        } else {
-            return {
-                id: "1000",
-                type: "participants",
-                dragHandle: "#dragHandle",
-                position: {x: 325, y: 200},
-                zIndex: 2,
-                data: {label: "Producer", source: "bottom", target: "top"},
-            }
-        }
+  const getProducers = (prod: any) => {
+    if (prod.length === 0) {
+      return {
+        id: "1000",
+        type: "producer",
+        dragHandle: "#dragHandle",
+        position: { x: 325, y: 200 },
+        zIndex: 2,
+        data: { label: "Producer", source: "bottom", target: "top" },
+      };
+    } else {
+      return {
+        id: "1000",
+        type: "producer",
+        dragHandle: "#dragHandle",
+        position: { x: 325, y: 200 },
+        zIndex: 2,
+        data: { label: "Producer", source: "bottom", target: "top" },
+      };
     }
+  };
 
-    const getConsumers = (prod : any) => {
-        if (prod.length === 0) {
-            return {
-                id: "2000",
-                type: "participants",
-                dragHandle: "#dragHandle",
-                position: {x: 50, y: 200},
-                zIndex: 2,
-                data: {label: "Consumer", source: "bottom", target: "top"},
-            }
-        } else {
-            return {
-                id: "2000",
-                type: "participants",
-                dragHandle: "#dragHandle",
-                position: {x: 50, y: 200},
-                zIndex: 2,
-                data: {label: "Consumer", source: "bottom", target: "top"},
-            }
-        }
+  const getConsumers = (prod: any) => {
+    if (prod.length === 0) {
+      return {
+        id: "2000",
+        type: "consumer",
+        dragHandle: "#dragHandle",
+        position: { x: 50, y: 200 },
+        zIndex: 2,
+        data: { label: "Consumer", source: "bottom", target: "top" },
+      };
+    } else {
+      return {
+        id: "2000",
+        type: "consumer",
+        dragHandle: "#dragHandle",
+        position: { x: 50, y: 200 },
+        zIndex: 2,
+        data: { label: "Consumer", source: "bottom", target: "top" },
+      };
     }
+  };
 
-    return (
-        <div
-            style={{width: "100%", height: "100vh", zIndex: 0}}
-            class="m-0 z-10"
-        >
-            <ReactFlow
-                nodes={nodes}
-                onNodesChange={onNodesChange}
-                edges={initialEdges}
-                nodeTypes={nodeTypes}
-                defaultViewport={{
-                    x: 0,
-                    y: 150,
-                    zoom: .85,
-                }}
-            >
-                <Background style={{height: "100vh"}}/>
-                <Controls position="top-right" style={{marginTop: "30px"}}/>
-            </ReactFlow>
-        </div>
-    );
+  return (
+    <div
+      style={{ width: "100%", height: "100vh", zIndex: 0 }}
+      class="m-0 z-10"
+    >
+      <ReactFlow
+        nodes={nodes}
+        onNodesChange={onNodesChange}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        defaultViewport={{
+          x: 0,
+          y: 150,
+          zoom: .85,
+        }}
+      >
+        <Background style={{ height: "100vh" }} />
+        <Controls position="top-right" style={{ marginTop: "30px" }} />
+      </ReactFlow>
+    </div>
+  );
 }

--- a/islands/flow.tsx
+++ b/islands/flow.tsx
@@ -1,7 +1,7 @@
 import ReactFlow, { Background, Controls, useEdgesState } from "reactflow";
 import {
+  Audience,
   Consumer,
-  Platform,
   Producer,
   Service,
 } from "../components/customNodes.tsx";
@@ -11,13 +11,26 @@ import {
 } from "https://esm.sh/v128/@reactflow/core@11.7.4/X-YS9AdHlwZXMvcmVhY3Q6cHJlYWN0L2NvbXBhdCxyZWFjdC1kb206cHJlYWN0L2NvbXBhdCxyZWFjdDpwcmVhY3QvY29tcGF0CmUvcHJlYWN0L2NvbXBhdA/denonext/core.mjs";
 import "flowbite";
 import { useEffect } from "https://esm.sh/preact@10.15.1/hooks";
-
+import { string } from "https://deno.land/x/zod@v3.21.4/types.ts";
 
 const nodeTypes = {
-  platform: Platform,
+  audience: Audience,
   producer: Producer,
   consumer: Consumer,
   service: Service,
+};
+
+export type Node = {
+  id: string;
+  type: string;
+  dragHandle: string;
+  position: {
+    x: number;
+    y: number;
+  };
+  data: {
+    label: string;
+  };
 };
 
 export default function Flow(props: any) {
@@ -25,6 +38,7 @@ export default function Flow(props: any) {
   const [edges, setEdges, onEdgeChange] = useEdgesState([]);
 
   useEffect(() => {
+    //this currently doesn't support more than one service or audience
     const keys = Object.keys(props.props.serviceMap);
     const serviceMap = props.props.serviceMap;
     let nodes = [
@@ -37,7 +51,7 @@ export default function Flow(props: any) {
       },
       {
         id: "10",
-        type: "platform",
+        type: "audience",
         sourcePosition: "right",
         targetPosition: "left",
         position: { x: 215, y: 350 },
@@ -54,16 +68,16 @@ export default function Flow(props: any) {
   }, []);
 
   useEffect(() => {
-    const newEdges = nodes.map((node: any, i: any) => {
+    const newEdges = nodes.map((node: Node, i: number) => {
       let targetNode;
       if (node.type === "service") {
-        targetNode = nodes.find((node) => node.type === "producer");
+        targetNode = nodes.find((node: Node) => node.type === "producer");
       } else if (node.type === "producer") {
-        targetNode = nodes.find((node) => node.type === "platform");
-      } else if (node.type === "platform") {
-        targetNode = nodes.find((node) => node.type === "consumer");
-      } else {
-        targetNode = nodes.find((node) => node.type === "service");
+        targetNode = nodes.find((node: Node) => node.type === "audience");
+      } else if (node.type === "audience") {
+        targetNode = nodes.find((node: Node) => node.type === "consumer");
+      } else if (node.type === "consumer") {
+        targetNode = nodes.find((node: Node) => node.type === "service");
       }
       return {
         id: i,
@@ -81,10 +95,10 @@ export default function Flow(props: any) {
         },
       };
     });
-    setEdges(newEdges)
+    setEdges(newEdges);
   }, [nodes]);
 
-  const getProducers = (prod: any) => {
+  const getProducers = (prod: []) => {
     if (prod.length === 0) {
       return {
         id: "1000",
@@ -106,7 +120,7 @@ export default function Flow(props: any) {
     }
   };
 
-  const getConsumers = (prod: any) => {
+  const getConsumers = (prod: []) => {
     if (prod.length === 0) {
       return {
         id: "2000",

--- a/routes/flow/index.tsx
+++ b/routes/flow/index.tsx
@@ -6,6 +6,7 @@ import {
   ReactFlowProvider,
 } from "https://esm.sh/v128/@reactflow/core@11.7.4/X-YS9AdHlwZXMvcmVhY3Q6cHJlYWN0L2NvbXBhdCxyZWFjdC1kb206cHJlYWN0L2NvbXBhdCxyZWFjdDpwcmVhY3QvY29tcGF0CmUvcHJlYWN0L2NvbXBhdA/denonext/core.mjs";
 import { client } from "../grpc.tsx";
+import { useEffect, useState } from "https://esm.sh/preact@10.15.1/hooks";
 
 interface ServiceMap {
   serviceMap: any;
@@ -26,7 +27,7 @@ export const handler: Handlers<ServiceMap> = {
     },
 };
 
-export default function FlowRoute({data} : {data: any}) {
+export default function FlowRoute({data}: any) {
   return (
     <Layout>
       <ReactFlowProvider>

--- a/routes/flow/index.tsx
+++ b/routes/flow/index.tsx
@@ -1,29 +1,36 @@
 import { Layout } from "../../components/layout.tsx";
 import { RuleSetType } from "../../components/rules/sets.tsx";
-import { PageProps } from "$fresh/src/server/types.ts";
+import { Handlers, PageProps } from "$fresh/src/server/types.ts";
 import Flow from "../../islands/flow.tsx";
 import {
   ReactFlowProvider,
 } from "https://esm.sh/v128/@reactflow/core@11.7.4/X-YS9AdHlwZXMvcmVhY3Q6cHJlYWN0L2NvbXBhdCxyZWFjdC1kb206cHJlYWN0L2NvbXBhdCxyZWFjdDpwcmVhY3QvY29tcGF0CmUvcHJlYWN0L2NvbXBhdA/denonext/core.mjs";
 import { client } from "../grpc.tsx";
 
-
-
-try {
-  const { response } = await client.getServiceMap({}, {
-    meta: { "auth-token": "1234" },
-  });
-
-  console.dir(response, {depth: 20});
-} catch (error) {
-  console.log("error", error);
+interface ServiceMap {
+  serviceMap: any;
 }
 
-export default function FlowRoute() {
+export const handler: Handlers<ServiceMap> = {
+  async GET(_req, ctx) {
+    try {
+      const { response } = await client.getServiceMap({}, {
+            meta: { "auth-token": "1234" },
+          });
+          console.dir(response, {depth: 20})
+          return ctx.render(response);
+        } catch (error) {
+          console.log(error)
+          return new Response("Project not found", { status: 404 });
+        }
+    },
+};
+
+export default function FlowRoute({data} : {data: any}) {
   return (
     <Layout>
       <ReactFlowProvider>
-        <Flow />
+        <Flow props={data}/>
       </ReactFlowProvider>
     </Layout>
   );

--- a/routes/flow/index.tsx
+++ b/routes/flow/index.tsx
@@ -31,7 +31,7 @@ export default function FlowRoute({data}: any) {
   return (
     <Layout>
       <ReactFlowProvider>
-        <Flow props={data}/>
+        <Flow data={data}/>
       </ReactFlowProvider>
     </Layout>
   );

--- a/routes/grpc.tsx
+++ b/routes/grpc.tsx
@@ -15,7 +15,7 @@ try {
     meta: { "auth-token": "1234" },
   });
   
-  console.log("test response:", response);
+  // console.log("test response:", response);
 } catch (error) {
   console.log("error", error);
 }


### PR DESCRIPTION
Wires up `getServiceMap` to create a map that can take multiple audiences (to do: refactor to take multiple components (i.e. kafka, https, mongo etc):

Current data being call from grpc `getServiceMap` call:
<img width="1100" alt="Screenshot 2023-08-01 at 3 15 43 PM" src="https://github.com/streamdal/snitch-console/assets/108096652/df12ddca-45bb-4d3f-9eb8-ad81fe8d8f58">

Tested with data that contains multiple consumers:
<img width="1100" alt="Screenshot 2023-08-01 at 3 17 05 PM" src="https://github.com/streamdal/snitch-console/assets/108096652/e756c7a3-ea33-4012-9e9f-7232f459fd50">
