### PR TITLE
Fix docker perms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ ADD . /app
 
 RUN deno cache main.ts
 
-CMD ["run", "--allow-net", "--allow-read", "--allow-env", "main.ts"]
+CMD ["run", "--allow-net", "--allow-read", "--allow-env", "--allow-write", "--allow-run", "main.ts"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     container_name: snitch-console-container
     image: snitch-console-image
     environment:
-      - SNITCH_GRPC_WEB_URL="http://localhost:9091"
+      - SNITCH_GRPC_WEB_URL="http://127.0.0.1:9091"
     ports:
       - "3000:3000"


### PR DESCRIPTION
Docker container fails to render dummy data unless --allow-run and --allow-write are added to the dockerfile.

```returning dummy data instead
An error occurred during route handling or page rendering. PermissionDenied: Requires run access to "/root/.cache/esbuild/bin/@esbuild-linux-x64@0.17.19", run again with the --allow-run flag
    at opRun (ext:runtime/40_process.js:46:14)``` 