### PR TITLE
detach bugs, unique keys and disable local store for now

### DIFF
--- a/components/modals/detachPipelineModal.tsx
+++ b/components/modals/detachPipelineModal.tsx
@@ -5,6 +5,7 @@ import { getAudienceOpRoute } from "../../lib/utils.ts";
 import { toastSignal } from "../toasts/toast.tsx";
 import IconUnlink from "tabler-icons/tsx/unlink.tsx";
 import { opModal } from "../serviceMap/opModalSignal.ts";
+import { opUpdateSignal } from "../../islands/serviceMap.tsx";
 
 export const DetachPipelineModal = (
   { audience, pipeline }: {
@@ -29,6 +30,11 @@ export const DetachPipelineModal = (
         id: "pipelineCrud",
         type: success.status ? "success" : "error",
         message: success.message,
+      };
+      opModal.value.attachedPipeline = null;
+      opUpdateSignal.value = {
+        audience,
+        attachedPipeline: null,
       };
     }
     close();

--- a/islands/serviceMap.tsx
+++ b/islands/serviceMap.tsx
@@ -1,12 +1,10 @@
 import ReactFlow, {
   Background,
-  ControlButton,
   Controls,
   useEdgesState,
   useNodesState,
 } from "reactflow";
 import "flowbite";
-import IconArrowBackUp from "tabler-icons/tsx/arrow-back-up.tsx";
 import {
   ComponentNode,
   GroupNode,
@@ -18,7 +16,6 @@ import { ServiceNodes } from "../lib/fetch.ts";
 import { Audience } from "snitch-protos/protos/common.ts";
 import { Pipeline } from "snitch-protos/protos/pipeline.ts";
 import { FlowEdge, FlowNode, updateNode } from "../lib/nodeMapper.ts";
-import { useEffect, useState } from "preact/hooks";
 
 const LAYOUT_KEY = "service-map-layout";
 
@@ -53,26 +50,18 @@ export default function ServiceMap(
     blur?: boolean;
   },
 ) {
-  const savedFlow = JSON.parse(localStorage.getItem(LAYOUT_KEY));
-  const [instance, setInstance] = useState(null);
   const [nodes, setNodes, onNodesChange] = useNodesState(
-    savedFlow?.nodes?.length > 0 ? savedFlow.nodes : nodesData,
+    nodesData,
   );
-  const [edges, setEdges, onEdgesChange] = useEdgesState(
-    savedFlow?.edges?.length > 0 ? savedFlow.edges : edgesData,
+  const [edges, onEdgesChange] = useEdgesState(
+    edgesData,
   );
 
-  const defaultViewport = savedFlow?.viewport ? savedFlow.viewport : {
+  const defaultViewport = {
     x: 0,
     y: 150,
     zoom: .85,
   };
-
-  useEffect(async () => {
-    if (instance) {
-      serialize(instance);
-    }
-  }, nodes);
 
   useSignalEffect(() => {
     if (opUpdateSignal.value) {
@@ -86,7 +75,6 @@ export default function ServiceMap(
       class={`w-full h-screen m-0 ${blur ? "filter blur-sm" : ""}`}
     >
       <ReactFlow
-        onInit={setInstance}
         nodes={nodes}
         edges={edges}
         onNodesChange={onNodesChange}
@@ -98,17 +86,7 @@ export default function ServiceMap(
         <Controls
           position="top-right"
           className="absolute top-[100px]"
-        >
-          <ControlButton
-            onClick={() => {
-              setNodes(nodesData), setEdges(edges);
-              localStorage.setItem(LAYOUT_KEY, null);
-            }}
-            title="reset view"
-          >
-            <IconArrowBackUp class="w-5 h-5" />
-          </ControlButton>
-        </Controls>
+        />
       </ReactFlow>
     </div>
   );

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,7 +1,6 @@
 import { client, meta } from "./grpc.ts";
 import { GetAllResponse } from "snitch-protos/protos/external.ts";
 import { PipelineInfo } from "snitch-protos/protos/info.ts";
-import { dummyAudiences, dummyConfig, dummyLive } from "./dummies.ts";
 import { Audience } from "snitch-protos/protos/common.ts";
 import { FlowEdge, FlowNode, mapEdges, mapNodes } from "./nodeMapper.ts";
 
@@ -16,11 +15,6 @@ export const getServiceMap = async (): Promise<ServiceMapType> => {
   const { response } = await client.getAll({}, meta);
   return {
     ...response,
-    //
-    // TODO: remove dummy data
-    ...response.audiences.length === 0 ? { audiences: dummyAudiences } : {},
-    ...response.live.length === 0 ? { live: dummyLive } : {},
-    ...Object.keys(response.config).length === 0 ? { config: dummyConfig } : {},
     pipes: Object.values(response?.pipelines),
   };
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -84,18 +84,13 @@ export const getOpRoute = (
     encodeURIComponent(component)
   }/${OperationType[opType]}/op/${encodeURIComponent(opName)}`;
 
+//
+//snitch server serialized audiences a bit oddly
+//and we need to do the same to interpret config keys
 export const audienceKey = (audience: Audience) =>
-  Object.values(
-    (({ serviceName, componentName, operationType, operationName }) => ({
-      serviceName,
-      componentName,
-      operationType,
-      operationName,
-    }))(audience),
-  ).map((
-    v: string | number,
-  ) => new String(v).toLowerCase())
-    .join("");
+  `${audience.serviceName}/operation_type_${
+    OperationType[audience.operationType]
+  }/${audience.operationName}/${audience.componentName}`.toLowerCase();
 
 export const getAttachedPipeline = (
   audience: Audience,


### PR DESCRIPTION
Fixed a bunch of bugs that I found while hitting it with a decent amount of new data from the node client: 
* My key strategy for nodes was not guaranteed to be unique, fixed
* Detach was not reflected in the ui in all places immediately
* updating flow node data in local storage on update broke very quickly with even a trivial amount of incoming changes...disabled for now...will dust off later and sort that out.