### PR TITLE
fix node id bugs and better handle non-deterministic ordering

### DIFF
--- a/components/form/formSelect.tsx
+++ b/components/form/formSelect.tsx
@@ -1,5 +1,4 @@
 import { ErrorType, parsePath, resolveValue, updateData } from "./validate.ts";
-import { DetectiveType } from "snitch-protos/protos/steps/detective.ts";
 import { isNumeric } from "../../lib/utils.ts";
 
 export type FormSelectProps = {

--- a/components/modals/detachPipelineModal.tsx
+++ b/components/modals/detachPipelineModal.tsx
@@ -1,6 +1,6 @@
 import IconX from "tabler-icons/tsx/x.tsx";
-import { Audience } from "snitch-protos/protos/common.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Audience } from "snitch-protos/protos/sp_common.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import { getAudienceOpRoute } from "../../lib/utils.ts";
 import { toastSignal } from "../toasts/toast.tsx";
 import IconUnlink from "tabler-icons/tsx/unlink.tsx";

--- a/components/modals/oddAttachModal.tsx
+++ b/components/modals/oddAttachModal.tsx
@@ -1,4 +1,4 @@
-import { PipelineInfo } from "snitch-protos/protos/info.ts";
+import { PipelineInfo } from "snitch-protos/protos/sp_info.ts";
 import IconPlus from "tabler-icons/tsx/plus.tsx";
 import { getAudienceOpRoute } from "../../lib/utils.ts";
 import { toastSignal } from "../toasts/toast.tsx";

--- a/components/modals/pausePipelineModal.tsx
+++ b/components/modals/pausePipelineModal.tsx
@@ -1,7 +1,7 @@
 import IconTrash from "tabler-icons/tsx/trash.tsx";
 import IconX from "tabler-icons/tsx/x.tsx";
-import { Audience } from "snitch-protos/protos/common.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Audience } from "snitch-protos/protos/sp_common.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import { getAudienceOpRoute } from "../../lib/utils.ts";
 import { toastSignal } from "../toasts/toast.tsx";
 import IconPlayerPause from "tabler-icons/tsx/player-pause.tsx";

--- a/components/pipeline/stepArgs.tsx
+++ b/components/pipeline/stepArgs.tsx
@@ -1,4 +1,4 @@
-import { DetectiveType } from "snitch-protos/protos/steps/detective.ts";
+import { DetectiveType } from "snitch-protos/protos/steps/sp_steps_detective.ts";
 import { FormInput } from "../form/formInput.tsx";
 import { ErrorType } from "../form/validate.ts";
 import { useState } from "preact/hooks";

--- a/components/pipeline/stepCondition.tsx
+++ b/components/pipeline/stepCondition.tsx
@@ -1,6 +1,6 @@
 import { ErrorType } from "../form/validate.ts";
 import { CheckboxGroup } from "../form/checkboxGroup.tsx";
-import { PipelineStepCondition } from "snitch-protos/protos/pipeline.ts";
+import { PipelineStepCondition } from "snitch-protos/protos/sp_pipeline.ts";
 
 export type StepConditionType = {
   stepIndex: number;

--- a/components/serviceMap/customNodes.tsx
+++ b/components/serviceMap/customNodes.tsx
@@ -2,7 +2,7 @@ import { Handle, Position } from "reactflow";
 import IconGripVertical from "tabler-icons/tsx/grip-vertical.tsx";
 import IconDatabase from "tabler-icons/tsx/database.tsx";
 import "twind";
-import { OperationType } from "snitch-protos/protos/common.ts";
+import { OperationType } from "snitch-protos/protos/sp_common.ts";
 import { NodeMenu, ServiceNodeMenu } from "./nodeMenu.tsx";
 import { ProducerIcon } from "../icons/producer.tsx";
 import { ConsumerIcon } from "../icons/consumer.tsx";

--- a/components/serviceMap/nodeMenu.tsx
+++ b/components/serviceMap/nodeMenu.tsx
@@ -1,8 +1,8 @@
 import { Edit, Info, Silence } from "../icons/crud.tsx";
 import { removeWhitespace } from "../../lib/utils.ts";
 import { opModal } from "./opModalSignal.ts";
-import { Audience } from "snitch-protos/protos/common.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Audience } from "snitch-protos/protos/sp_common.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import { NodeData } from "./customNodes.tsx";
 import IconDots from "tabler-icons/tsx/dots.tsx";
 import IconPlayerPause from "tabler-icons/tsx/player-pause.tsx";

--- a/components/serviceMap/opModalSignal.ts
+++ b/components/serviceMap/opModalSignal.ts
@@ -1,6 +1,6 @@
 import { signal } from "@preact/signals";
-import { Audience } from "snitch-protos/protos/common.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Audience } from "snitch-protos/protos/sp_common.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 
 export type OpModalType = {
   audience: Audience;

--- a/import_map.json
+++ b/import_map.json
@@ -18,7 +18,7 @@
     "@protobuf-ts/runtime": "https://esm.sh/@protobuf-ts/runtime@^2.9.0",
     "@protobuf-ts/runtime-rpc": "https://esm.sh/@protobuf-ts/runtime-rpc@^2.9.0",
     "@protobuf-ts/grpcweb-transport": "https://esm.sh/@protobuf-ts/grpcweb-transport@^2.9.0",
-    "snitch-protos/": "https://deno.land/x/snitch_protos@v0.0.66/",
+    "snitch-protos/": "https://deno.land/x/snitch_protos@v0.0.77/",
     "zod": "https://deno.land/x/zod@v3.21.4",
     "zod/": "https://deno.land/x/zod@v3.21.4/",
     "zod-form-data": "https://esm.sh/zod-form-data@^2.0.1",

--- a/islands/opModal.tsx
+++ b/islands/opModal.tsx
@@ -7,7 +7,7 @@ import IconUnlink from "tabler-icons/tsx/unlink.tsx";
 import { titleCase } from "../lib/utils.ts";
 import { ServiceMapType } from "../lib/fetch.ts";
 import { opModal } from "../components/serviceMap/opModalSignal.ts";
-import { OperationType } from "snitch-protos/protos/common.ts";
+import { OperationType } from "snitch-protos/protos/sp_common.ts";
 import IconLink from "tabler-icons/tsx/link.tsx";
 import IconPlayerPause from "tabler-icons/tsx/player-pause.tsx";
 import { Toast } from "../components/toasts/toast.tsx";

--- a/islands/pipeline.tsx
+++ b/islands/pipeline.tsx
@@ -8,9 +8,9 @@ import {
   Pipeline,
   PipelineStep,
   PipelineStepCondition,
-} from "snitch-protos/protos/pipeline.ts";
-import { DetectiveType } from "snitch-protos/protos/steps/detective.ts";
-import { TransformType } from "snitch-protos/protos/steps/transform.ts";
+} from "snitch-protos/protos/sp_pipeline.ts";
+import { DetectiveType } from "snitch-protos/protos/steps/sp_steps_detective.ts";
+import { TransformType } from "snitch-protos/protos/steps/sp_steps_transform.ts";
 import { zfd } from "zod-form-data";
 import * as z from "zod/index.ts";
 

--- a/islands/pipelines.tsx
+++ b/islands/pipelines.tsx
@@ -1,7 +1,7 @@
 import IconPencil from "tabler-icons/tsx/pencil.tsx";
 import IconPlus from "tabler-icons/tsx/plus.tsx";
 
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import { Tooltip } from "../components/tooltip/tooltip.tsx";
 import PipelineDetail, { newPipeline } from "./pipeline.tsx";
 import { SuccessType } from "../routes/_middleware.ts";

--- a/islands/serviceMap.tsx
+++ b/islands/serviceMap.tsx
@@ -13,8 +13,8 @@ import {
 } from "../components/serviceMap/customNodes.tsx";
 import { signal, useSignalEffect } from "@preact/signals";
 import { ServiceNodes } from "../lib/fetch.ts";
-import { Audience } from "snitch-protos/protos/common.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Audience } from "snitch-protos/protos/sp_common.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import { FlowEdge, FlowNode, updateNode } from "../lib/nodeMapper.ts";
 
 const LAYOUT_KEY = "service-map-layout";

--- a/lib/dummies.ts
+++ b/lib/dummies.ts
@@ -1,7 +1,7 @@
-import { GetAllResponse } from "snitch-protos/protos/external.ts";
-import { OperationType } from "snitch-protos/protos/common.ts";
-import { DetectiveType } from "snitch-protos/protos/steps/detective.ts";
-import { ClientType } from "snitch-protos/protos/info.ts";
+import { GetAllResponse } from "snitch-protos/protos/sp_external.ts";
+import { OperationType } from "snitch-protos/protos/sp_common.ts";
+import { DetectiveType } from "snitch-protos/protos/steps/sp_steps_detective.ts";
+import { ClientType } from "snitch-protos/protos/sp_info.ts";
 import { audienceKey } from "./utils.ts";
 
 export const dummyPipelines = [{

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,7 +1,7 @@
 import { client, meta } from "./grpc.ts";
-import { GetAllResponse } from "snitch-protos/protos/external.ts";
-import { PipelineInfo } from "snitch-protos/protos/info.ts";
-import { Audience } from "snitch-protos/protos/common.ts";
+import { GetAllResponse } from "snitch-protos/protos/sp_external.ts";
+import { PipelineInfo } from "snitch-protos/protos/sp_info.ts";
+import { Audience } from "snitch-protos/protos/sp_common.ts";
 import { FlowEdge, FlowNode, mapEdges, mapNodes } from "./nodeMapper.ts";
 
 export type ServiceMapType = GetAllResponse & {

--- a/lib/grpc.ts
+++ b/lib/grpc.ts
@@ -1,7 +1,7 @@
 import {
   ExternalClient,
   IExternalClient,
-} from "snitch-protos/protos/external.client.ts";
+} from "snitch-protos/protos/sp_external.client.ts";
 import { GrpcWebFetchTransport } from "@protobuf-ts/grpcweb-transport";
 
 export const meta = {

--- a/lib/mutation.ts
+++ b/lib/mutation.ts
@@ -2,14 +2,14 @@ import {
   Audience,
   ResponseCode,
   StandardResponse,
-} from "snitch-protos/protos/common.ts";
+} from "snitch-protos/protos/sp_common.ts";
 import { client, meta } from "./grpc.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import {
   AttachPipelineRequest,
   DetachPipelineRequest,
   PausePipelineRequest,
-} from "snitch-protos/protos/external.ts";
+} from "snitch-protos/protos/sp_external.ts";
 
 export type PatchedPipelineResponse = StandardResponse & {
   pipelineId?: string;

--- a/lib/nodeMapper.ts
+++ b/lib/nodeMapper.ts
@@ -1,6 +1,6 @@
-import { Audience, OperationType } from "snitch-protos/protos/common.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
-import { ClientInfo, LiveInfo } from "snitch-protos/protos/info.ts";
+import { Audience, OperationType } from "snitch-protos/protos/sp_common.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
+import { ClientInfo, LiveInfo } from "snitch-protos/protos/sp_info.ts";
 import { ServiceMapType } from "./fetch.ts";
 import {
   componentKey,

--- a/lib/nodeMapper.ts
+++ b/lib/nodeMapper.ts
@@ -3,9 +3,10 @@ import { Pipeline } from "snitch-protos/protos/pipeline.ts";
 import { ClientInfo, LiveInfo } from "snitch-protos/protos/info.ts";
 import { ServiceMapType } from "./fetch.ts";
 import {
-  audienceKey,
   componentKey,
   getAttachedPipeline,
+  groupKey,
+  operationKey,
   serviceKey,
 } from "./utils.ts";
 import { MarkerType } from "reactflow";
@@ -39,10 +40,11 @@ type GroupCountKey = "producer" | "consumer";
 export type GroupCount = { [key in GroupCountKey]: number };
 
 //
-// group counts per service are used for vertical offset layout positions
+// the service map is used for x-axis offset layout positions and
+// group counts per service are used for y-axix offset layout positions
 export type NodesMap = {
   nodes: Map<string, FlowNode>;
-  groupCount: Map<string, GroupCount>;
+  services: Map<string, GroupCount>;
 };
 
 export type FlowEdge = {
@@ -53,8 +55,10 @@ export type FlowEdge = {
   style: any;
 };
 
-export const xOffset = (serviceCount: number) =>
-  serviceCount > 1 ? (serviceCount - 1) * 800 : 0;
+export const xOffset = (
+  audience: Audience,
+  services: Map<string, GroupCount>,
+) => Array.from(services.keys()).indexOf(serviceKey(audience)) * 800;
 
 export const mapOperation = (
   nodesMap: NodesMap,
@@ -62,19 +66,19 @@ export const mapOperation = (
   serviceMap: ServiceMapType,
 ) => {
   const op = OperationType[a.operationType].toLowerCase() as GroupCountKey;
-  const groupCount = nodesMap.groupCount.get(a.serviceName)!;
+  const groupCount = nodesMap.services.get(serviceKey(a))!;
   groupCount.producer = groupCount.producer + (op === "producer" ? 1 : 0);
   groupCount.consumer = groupCount.consumer + (op === "consumer" ? 1 : 0);
-  nodesMap.groupCount.set(a.serviceName, groupCount);
+  nodesMap.services.set(serviceKey(a), groupCount);
 
-  nodesMap.nodes.set(`${a.serviceName}-${a.componentName}-${op}`, {
-    id: `${audienceKey(a)}-group`,
+  nodesMap.nodes.set(groupKey(a), {
+    id: groupKey(a),
     type: `${op}Group`,
     sourcePosition: "right",
     targetPosition: "left",
     dragHandle: "#dragHandle",
     position: {
-      x: (op === "consumer" ? 25 : 350) + xOffset(nodesMap.groupCount.size),
+      x: (op === "consumer" ? 25 : 350) + xOffset(a, nodesMap.services),
       y: 200,
     },
     data: {
@@ -83,15 +87,15 @@ export const mapOperation = (
     },
   });
 
-  nodesMap.nodes.set(a.operationName, {
-    id: `${audienceKey(a)}-operation`,
+  nodesMap.nodes.set(operationKey(a), {
+    id: operationKey(a),
     draggable: false,
     type: op,
     position: {
       x: 10,
       y: 38 + ((groupCount[op] - 1) * 80),
     },
-    parentNode: `${audienceKey(a)}-group`,
+    parentNode: groupKey(a),
     extent: "parent",
     data: {
       audience: a,
@@ -116,19 +120,19 @@ export const mapNodes = (
 ): NodesMap => {
   const nodesMap = {
     nodes: new Map<string, FlowNode>(),
-    groupCount: new Map<string, GroupCount>(),
+    services: new Map<string, GroupCount>(),
   };
 
   serviceMap.audiences.forEach((a: Audience) => {
-    if (!nodesMap.groupCount.has(a.serviceName)) {
-      nodesMap.groupCount.set(a.serviceName, { producer: 0, consumer: 0 });
+    if (!nodesMap.services.has(serviceKey(a))) {
+      nodesMap.services.set(serviceKey(a), { producer: 0, consumer: 0 });
     }
 
-    nodesMap.nodes.set(a.serviceName, {
-      id: `${serviceKey(a)}-service`,
+    nodesMap.nodes.set(serviceKey(a), {
+      id: serviceKey(a),
       type: "service",
       dragHandle: "#dragHandle",
-      position: { x: 150 + xOffset(nodesMap.groupCount.size), y: 0 },
+      position: { x: 150 + xOffset(a, nodesMap.services), y: 0 },
       data: { audience: a },
     });
 
@@ -136,20 +140,20 @@ export const mapNodes = (
 
     //
     // guaranteed to be initialized above
-    const groupCount = nodesMap.groupCount.get(a.serviceName)!;
+    const groupCount = nodesMap.services.get(serviceKey(a))!;
     const count = Math.max(
       groupCount["producer"] || 1,
       groupCount["consumer"] || 1,
     );
 
     nodesMap.nodes.set(a.componentName, {
-      id: `${componentKey(a)}-component`,
+      id: componentKey(a),
       type: "component",
       sourcePosition: "right",
       targetPosition: "left",
       dragHandle: "#dragHandle",
       position: {
-        x: 240 + xOffset(nodesMap.groupCount.size),
+        x: 240 + xOffset(a, nodesMap.services),
         y: 350 + (count - 1) * 76,
       },
       data: { audience: a },
@@ -168,16 +172,16 @@ export const mapEdgePair = (
   a: Audience,
 ): Map<string, FlowEdge> => {
   const op = OperationType[a.operationType].toLowerCase();
-  edgesMap.set(`${audienceKey(a)}-component-edge`, {
-    id: `${audienceKey(a)}-component-edge`,
+  edgesMap.set(`${componentKey(a)}-${op}-edge`, {
+    id: `${componentKey(a)}-${op}-edge`,
     ...op === "consumer"
       ? {
-        source: `${componentKey(a)}-component`,
-        target: `${audienceKey(a)}-group`,
+        source: componentKey(a),
+        target: groupKey(a),
       }
       : {
-        source: `${audienceKey(a)}-group`,
-        target: `${componentKey(a)}-component`,
+        source: groupKey(a),
+        target: componentKey(a),
       },
     markerEnd: {
       type: MarkerType.Arrow,
@@ -191,16 +195,16 @@ export const mapEdgePair = (
     },
   });
 
-  edgesMap.set(`${audienceKey(a)}-service-edge`, {
-    id: `${audienceKey(a)}-service-edge`,
+  edgesMap.set(`${serviceKey(a)}-${op}-edge`, {
+    id: `${serviceKey(a)}-${op}-edge`,
     ...op === "consumer"
       ? {
-        source: `${audienceKey(a)}-group`,
-        target: `${serviceKey(a)}-service`,
+        source: groupKey(a),
+        target: serviceKey(a),
       }
       : {
-        source: `${serviceKey(a)}-service`,
-        target: `${audienceKey(a)}-group`,
+        source: serviceKey(a),
+        target: groupKey(a),
       },
     markerEnd: {
       type: MarkerType.Arrow,
@@ -230,7 +234,7 @@ export const mapEdges = (audiences: Audience[]): Map<string, FlowEdge> => {
 export const updateNode = (nodes: FlowNode[], update: OpUpdate) =>
   nodes.map((n: FlowNode) =>
     n.id ===
-        `${update.audience.serviceName}-${update.audience.operationName}`
+        operationKey(update.audience)
       ? {
         ...n,
         data: {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -93,10 +93,20 @@ export const audienceKey = (audience: Audience) =>
   }/${audience.operationName}/${audience.componentName}`.toLowerCase();
 
 export const serviceKey = (audience: Audience) =>
-  lower(`${audience.serviceName}`.toLowerCase());
+  lower(`${audience.serviceName}-service`.toLowerCase());
 
 export const componentKey = (audience: Audience) =>
-  lower(`${audience.serviceName}`);
+  lower(`${audience.componentName}-component`);
+
+export const operationKey = (audience: Audience) =>
+  lower(`${audienceKey(audience)}-operation`);
+
+export const groupKey = (audience: Audience) =>
+  lower(
+    `${audience.serviceName}-${
+      OperationType[audience.operationType]
+    }-${audience.componentName}-group`,
+  );
 
 export const lower = (s: string) => s.toLowerCase();
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import { Audience, OperationType } from "snitch-protos/protos/common.ts";
+import { Audience, OperationType } from "snitch-protos/protos/sp_common.ts";
 import { ConfigType, PipelinesType } from "./fetch.ts";
 
 const UNITS = [

--- a/routes/pipelines/[id]/delete.tsx
+++ b/routes/pipelines/[id]/delete.tsx
@@ -1,7 +1,7 @@
 import { Handlers, PageProps } from "$fresh/src/server/types.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import { getPipeline, getPipelines } from "../../../lib/fetch.ts";
-import { ResponseCode } from "snitch-protos/protos/common.ts";
+import { ResponseCode } from "snitch-protos/protos/sp_common.ts";
 import { deletePipeline } from "../../../lib/mutation.ts";
 import { RoutedDeleteModal } from "../../../components/modals/routedDeleteModal.tsx";
 import Pipelines from "../../../islands/pipelines.tsx";

--- a/routes/pipelines/index.tsx
+++ b/routes/pipelines/index.tsx
@@ -1,5 +1,5 @@
 import { Handlers, PageProps } from "$fresh/src/server/types.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import Pipelines from "../../islands/pipelines.tsx";
 import { getPipelines } from "../../lib/fetch.ts";
 import { SuccessType } from "../_middleware.ts";

--- a/routes/pipelines/save.tsx
+++ b/routes/pipelines/save.tsx
@@ -1,8 +1,8 @@
 import { Handlers } from "$fresh/src/server/types.ts";
-import { Pipeline } from "snitch-protos/protos/pipeline.ts";
+import { Pipeline } from "snitch-protos/protos/sp_pipeline.ts";
 import { ErrorType, validate } from "../../components/form/validate.ts";
 import { pipelineSchema } from "../../islands/pipeline.tsx";
-import { ResponseCode } from "snitch-protos/protos/common.ts";
+import { ResponseCode } from "snitch-protos/protos/sp_common.ts";
 import { upsertPipeline } from "../../lib/mutation.ts";
 import { SuccessType } from "../_middleware.ts";
 

--- a/routes/service/[service]/component/[component]/[operationType]/op/[operationName]/pipeline/[id]/attach.tsx
+++ b/routes/service/[service]/component/[component]/[operationType]/op/[operationName]/pipeline/[id]/attach.tsx
@@ -1,6 +1,6 @@
 import { Handlers } from "$fresh/src/server/types.ts";
 import { SuccessType } from "../../../../../../../../../_middleware.ts";
-import { OperationType, ResponseCode } from "snitch-protos/protos/common.ts";
+import { OperationType, ResponseCode } from "snitch-protos/protos/sp_common.ts";
 import { attachPipeline } from "../../../../../../../../../../lib/mutation.ts";
 import { HandlerContext } from "$fresh/server.ts";
 

--- a/routes/service/[service]/component/[component]/[operationType]/op/[operationName]/pipeline/[id]/detach.tsx
+++ b/routes/service/[service]/component/[component]/[operationType]/op/[operationName]/pipeline/[id]/detach.tsx
@@ -1,6 +1,6 @@
 import { Handlers } from "$fresh/src/server/types.ts";
 import { SuccessType } from "../../../../../../../../../_middleware.ts";
-import { OperationType, ResponseCode } from "snitch-protos/protos/common.ts";
+import { OperationType, ResponseCode } from "snitch-protos/protos/sp_common.ts";
 import { detachPipeline } from "../../../../../../../../../../lib/mutation.ts";
 import { HandlerContext } from "$fresh/server.ts";
 

--- a/routes/service/[service]/component/[component]/[operationType]/op/[operationName]/pipeline/[id]/pause.tsx
+++ b/routes/service/[service]/component/[component]/[operationType]/op/[operationName]/pipeline/[id]/pause.tsx
@@ -1,6 +1,6 @@
 import { Handlers } from "$fresh/src/server/types.ts";
 import { SuccessType } from "../../../../../../../../../_middleware.ts";
-import { OperationType, ResponseCode } from "snitch-protos/protos/common.ts";
+import { OperationType, ResponseCode } from "snitch-protos/protos/sp_common.ts";
 import { HandlerContext } from "$fresh/server.ts";
 import { pausePipeline } from "../../../../../../../../../../lib/fetch.ts";
 


### PR DESCRIPTION
In order to draw the our react flow nodes we need to map services, operations, groups and components (separately) to unique dom identifiers. We also need to process nodes in order and keep counts of processed services and groups for layout purposes. Previous node mapping happened to work based on the ordering of the dummy data, this fixes that so that it works no matter what order the audiences arrive in..

Also, the protos were out of date...so I updated to the new protos with the namespace.