### PR TITLE
fix multiple step arg bugs

### DIFF
--- a/components/pipeline/stepArgs.tsx
+++ b/components/pipeline/stepArgs.tsx
@@ -62,8 +62,16 @@ export const StepArg = (
 export const StepArgs = (
   { stepIndex, type, data, setData, errors }: StepArgsType,
 ) => {
-  const [args, setArgs] = useState([0]);
-  return oneArgTypes.includes(type)
+  //
+  // Peek into step to see how many args there are so we
+  // can tell the ui how many args to render initiallly
+  const length = data?.steps[stepIndex]
+    ?.step[data?.steps[stepIndex]?.step?.oneofKind]?.args?.length || 0;
+  const [args, setArgs] = useState(Array.from({ length }, (v, k) => k));
+
+  return oneArgTypes.filter((a: string) =>
+      !["STRING_CONTAINS_ANY", "STRING_CONTAINS_ALL"]
+    ).includes(type)
     ? (
       <StepArg
         stepIndex={stepIndex}

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.0.9";
+export const version = "1.1.0";


### PR DESCRIPTION
Previously we were not showing multiple step args by default and we not properly validating arg types where one or more are valid.