### PR TITLE
version fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,20 @@ This console needs a snitch-server to run against. See
 [snitch-server](https://github.com/streamdal/snitch-server) for instructions on
 running it locally.
 
-### Versions
-
-Update `verstion.ts` to display a new version in the app. See:
-`https://deno.land/x/version_ts@0.2.2` to make this a little easier.
-
 ### Running (non-development)
 
 If you just want to run the console and the server together for non-development
 purposes, you can bring them both up with docker, see:
 https://github.com/streamdal/snitch/tree/main/docker/local
+
+### Releasing
+
+We use https://deno.land/x/version_ts@0.2.2 to help set our release version. To
+generate a release:
+
+1. Install `version_ts` if you don't already have it:
+   `deno install -f -r --allow-read=version.ts --allow-write=version.ts --allow-run=git https://deno.land/x/version_ts/main.ts`
+2. Bump the release number: `version_ts [major|minor|patch] --commit --tag`
+3. git push the generated version tag: `git push origin <tag_name>`
+4. Generate a release from the tag with user-friendly release notes:
+   https://github.com/streamdal/snitch-node-client/releases

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     build: .
     container_name: snitch-console-container
-    image: streamdal/snitch-console:latest
+    image: streamdal/snitch-console:v0.1.20
     environment:
       - SNITCH_GRPC_WEB_URL=http://host.docker.internal:9091
       - SNITCH_GRPC_AUTH_TOKEN="1234"

--- a/version.ts
+++ b/version.ts
@@ -1,3 +1,1 @@
-
-export const version = "1.1.0";
-
+export const version = "0.1.20";


### PR DESCRIPTION
We bumped ourselves to 1 too soon and diverged from semantic versioning. This moves us back down to pre-release and add some notes the the readme about using a tool bump our versions.

Once this is merged I will do a new release, clean up our version tags in github and our images in docker hub.