### PR TITLE
peek status signal and grpc stream abort

### DIFF
--- a/islands/opModal.tsx
+++ b/islands/opModal.tsx
@@ -20,10 +20,13 @@ import { EmptyStateBird } from "../components/icons/emptyStateBird.tsx";
 import { useState } from "preact/hooks";
 import { useSignalEffect } from "@preact/signals";
 import { Peek } from "./peek.tsx";
-import { initFlowbite } from "flowbite";
 import { Toggle } from "../components/form/switch.tsx";
 import { isNumeric } from "../lib/utils.ts";
-import { peekSamplingRateSignal, peekSamplingSignal } from "../lib/peek.ts";
+import {
+  peekingSignal,
+  peekSamplingRateSignal,
+  peekSamplingSignal,
+} from "../lib/peek.ts";
 
 export const OP_MODAL_WIDTH = "80px";
 export const OP_MODAL_OPEN_WIDTH = "308px";
@@ -42,7 +45,6 @@ export default function OpModal(
 
   const [isOpen, setIsOpen] = useState(false);
   const [peekNavOpen, setPeekNavOpen] = useState(false);
-  const [peeking, setPeeking] = useState(false);
 
   useSignalEffect(() => {
     if (opModal.value) {
@@ -65,14 +67,13 @@ export default function OpModal(
         />
       )}
       <div class="flex flex-row">
-        {peeking && (
+        {peekingSignal.value && (
           <Peek
             audience={audience}
             pipeline={attachedPipeline}
             modalExpanded={isOpen}
             grpcUrl={grpcUrl}
             grpcToken={grpcToken}
-            close={() => setPeeking(false)}
           />
         )}
         <div
@@ -310,13 +311,15 @@ export default function OpModal(
                               <button
                                 onClick={() =>
                                   attachedPipeline
-                                    ? setPeeking(!peeking)
+                                    ? peekingSignal.value = !peekingSignal.value
                                     : null}
                                 className={`text-white bg-web rounded-md w-[260px] h-[34px] flex justify-center items-center font-medium text-sm mb-4 cursor-${
                                   attachedPipeline ? "pointer" : "not-allowed"
                                 }`}
                               >
-                                {peeking ? "Stop Peeking" : "Start Peeking"}
+                                {peekingSignal.value
+                                  ? "Stop Peeking"
+                                  : "Start Peeking"}
                               </button>
                             </div>
                           )

--- a/islands/peek.tsx
+++ b/islands/peek.tsx
@@ -8,7 +8,12 @@ import IconWindowMaximize from "tabler-icons/tsx/window-maximize.tsx";
 import IconX from "tabler-icons/tsx/x.tsx";
 
 import { useEffect, useRef, useState } from "preact/hooks";
-import { peek, peekPausedSignal, peekSignal } from "../lib/peek.ts";
+import {
+  peek,
+  peekingSignal,
+  peekPausedSignal,
+  peekSignal,
+} from "../lib/peek.ts";
 import { effect } from "@preact/signals";
 
 export const parseData = (data: Uint8Array) => {
@@ -71,14 +76,12 @@ export const Peek = (
     modalExpanded,
     grpcToken,
     grpcUrl,
-    close,
   }: {
     audience: Audience;
     pipeline: Pipeline;
     modalExpanded: boolean;
     grpcUrl: string;
     grpcToken: string;
-    close: () => void;
   },
 ) => {
   const [peekData, setPeekData] = useState();
@@ -140,7 +143,7 @@ export const Peek = (
             </div>
             <div
               className="ml-2 flex justify-center items-center w-[36px] h-[36px] rounded-[50%] bg-streamdalPurple cursor-pointer"
-              onClick={close}
+              onClick={() => peekingSignal.value = false}
             >
               <IconX class="w-6 h-6 text-white" />
             </div>


### PR DESCRIPTION
Move peek active indicator to a preact signal so we can set and check it from anywhere. Add signal hook to peek stream and abort it when peek is cancelled.