### PR TITLE
reinit flowbite after audience change

### DIFF
--- a/islands/opModal.tsx
+++ b/islands/opModal.tsx
@@ -31,6 +31,7 @@ import IconWindowMaximize from "tabler-icons/tsx/window-maximize.tsx";
 import { SchemaModal } from "../components/modals/schemaModal.tsx";
 import { ComponentImage } from "./customNodes.tsx";
 import { useSignalEffect } from "@preact/signals";
+import { initFlowbite } from "flowbite";
 
 import { BetaTag, ComingSoonTag } from "../components/icons/featureTags.tsx";
 export const OP_MODAL_WIDTH = "308px";
@@ -97,6 +98,9 @@ export default function OpModal(
   });
 
   useEffect(async () => {
+    //
+    // Flowbite breaks on audience change for some reason
+    initFlowbite();
     if (opModal.value) {
       const schema = await getSchema();
       opModal.value = {


### PR DESCRIPTION
I noticed flowbite handlers for dropdowns, tooltips, etc. break after audience change..manually reinit it for now until we can figure out why.